### PR TITLE
Enable test runs outside build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,3 +92,9 @@ add_test(
         NAME tests
         COMMAND tests
 )
+
+set_tests_properties(
+        tests
+        PROPERTIES
+        ENVIRONMENT TEST_DATA_DIR=${CMAKE_SOURCE_DIR}/test_data
+)

--- a/src/tests.cc
+++ b/src/tests.cc
@@ -611,6 +611,14 @@ void RunEndToEndFilesTestFor(
       expected_compressed_size);
 }
 
+std::string GetTestDataPath() {
+  // NOTE: This expects that either the test data path is provided through
+  // the TEST_DATA_DIR environment variable or that the test data dir exists one
+  // level above the test's working directory
+  auto dir_name = std::getenv("TEST_DATA_DIR");
+  return dir_name == nullptr ? "../test_data" : dir_name;
+}
+
 // Test summary:
 // For a small file (less than block size) and a general file (a few blocks
 //   plus a few additional bytes):
@@ -620,9 +628,9 @@ void RunEndToEndFilesTestFor(
 // Ensure that the new output file matches the original file. A seed file is
 // required and for this, the original file is used.
 TEST(SyncCommand, EndToEndFiles) {  // NOLINT
-  // NOTE: This currently assumes that a test data dir exists one
-  // level above the test's working directory
-  std::string test_data_path = "../test_data";
+  std::string test_data_path = GetTestDataPath();
+  LOG(INFO) << "Using test data path: " << test_data_path;  
+
   const uint64_t kExpectedCompressedSize = 42;
   RunEndToEndFilesTestFor(
       test_data_path + "/test_file_small.txt",
@@ -638,9 +646,9 @@ TEST(SyncCommand, EndToEndFiles) {  // NOLINT
 // 2. Run sync.
 // Ensure that newly sync'd file matches the original non-compressed v2 file.
 TEST(SyncCommand, SyncFileFromSeed) {  // NOLINT
-  // NOTE: This currently assumes that a test data dir exists one
-  // level above the test's working directory
-  std::string test_data_path = "../test_data";
+  std::string test_data_path = GetTestDataPath();
+  LOG(INFO) << "Using test data path: " << test_data_path;
+
   std::string sync_file_name = test_data_path + "/test_file_v2.txt";
   std::string seed_file_name = test_data_path + "/test_file.txt";
   TempPathProvider temp_path_provider;
@@ -664,9 +672,9 @@ TEST(SyncCommand, SyncFileFromSeed) {  // NOLINT
 
 // Test syncing from a non-compressed file
 TEST(SyncCommand, SyncNonCompressedFile) {  // NOLINT
-  // NOTE: This currently assumes that a test data dir exists one
-  // level above the test's working directory
-  std::string test_data_path = "../test_data";
+  std::string test_data_path = GetTestDataPath();
+  LOG(INFO) << "Using test data path: " << test_data_path;
+
   std::string sync_file_name = test_data_path + "/test_file_v2.txt";
   std::string seed_file_name = test_data_path + "/test_file.txt";
   TempPathProvider temp_path_provider;


### PR DESCRIPTION
The run using ctest automatically takes the environment variable. As an example:
```
ashish@ash-alienw-r11:~/git/ksync/build$ /home/ashish/.local/bin/ctest -j18 -C Debug -T test -V
gives
...
[ RUN      ] SyncCommand.SyncNonCompressedFile
1: I0404 17:57:31.652268  9919 tests.cc:676] Using test data path: /home/ashish/git/ksync/test_data
...
1: [  PASSED  ] 14 tests.
1/1 Test #1: tests ............................   Passed    2.71 sec

100% tests passed, 0 tests failed out of 1

```

The tests binary can be run directly outside the build dir by providing the env variable. An example is:
```
ashish@ash-alienw-r11:~/git/ksync$ env TEST_DATA_DIR=/home/ashish/git/ksync/test_data ./build/tests
which gives output of the following form:
...
[       OK ] SyncCommand.SyncFileFromSeed (165 ms)
[ RUN      ] SyncCommand.SyncNonCompressedFile
I0404 17:54:57.211200  9756 tests.cc:676] Using test data path: /home/ashish/git/ksync/test_data
I0404 17:54:57.325017  9756 SyncCommand.cc:405] reading metadata...
I0404 17:54:57.325116  9756 SyncCommand.cc:407] analyzing seed data...
I0404 17:54:57.325148  9756 SyncCommand.cc:208] GetSize too small... not using parallelization
I0404 17:54:57.325584  9756 SyncCommand.cc:409] reconstructing target...
I0404 17:54:57.325645  9756 SyncCommand.cc:208] GetSize too small... not using parallelization
[       OK ] SyncCommand.SyncNonCompressedFile (126 ms)
[----------] 5 tests from SyncCommand (2847 ms total)

[----------] Global test environment tear-down
[==========] 14 tests from 5 test suites ran. (2848 ms total)
[  PASSED  ] 14 tests.

```

```
The variable only needs to be provided for the command (example):
ashish@ash-alienw-r11:~/git/ksync$ printenv | grep -i TEST
ashish@ash-alienw-r11:~/git/ksync$ 

```