### PR TITLE
add PosixSequentialFileReader that uses raw C/posix and use fdadvise(…

### DIFF
--- a/src/readers/CMakeLists.txt
+++ b/src/readers/CMakeLists.txt
@@ -2,7 +2,8 @@ add_library(kysync_readers
         reader.cc
         memory_reader.cc
         file_reader.cc
-        http_reader.cc)
+        http_reader.cc
+        posix_sequential_file_reader.cc)
 target_link_libraries(kysync_readers
         PUBLIC ky_metrics
         PRIVATE ky_common

--- a/src/readers/include/posix_sequential_file_reader.h
+++ b/src/readers/include/posix_sequential_file_reader.h
@@ -1,0 +1,29 @@
+#ifndef KSYNC_SRC_READERS_INCLUDE_KYSYNC_READERS_POSIX_SEQUENTIAL_FILE_READER_H
+#define KSYNC_SRC_READERS_INCLUDE_KYSYNC_READERS_POSIX_SEQUENTIAL_FILE_READER_H
+
+#include <kysync/readers/reader.h>
+
+#include <filesystem>
+#include <fstream>
+
+namespace kysync {
+
+class PosixSequentialFileReader final : public Reader {
+  std::filesystem::path path_;
+
+  int fd_;
+  std::streamoff cached_current_offset_;
+
+public:
+  explicit PosixSequentialFileReader(const std::filesystem::path &path);
+  virtual ~PosixSequentialFileReader();
+
+  [[nodiscard]] std::streamsize GetSize() const override;
+
+  std::streamsize
+  Read(void *buffer, std::streamoff offset, std::streamsize size) override;
+};
+
+}  // namespace kysync
+
+#endif  // KSYNC_SRC_READERS_INCLUDE_KYSYNC_READERS_POSIX_SEQUENTIAL_FILE_READER_H

--- a/src/readers/posix_sequential_file_reader.cc
+++ b/src/readers/posix_sequential_file_reader.cc
@@ -1,0 +1,41 @@
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <glog/logging.h>
+#include <kysync/readers/posix_sequential_file_reader.h>
+
+namespace kysync {
+
+namespace fs = std::filesystem;
+
+PosixSequentialFileReader::PosixSequentialFileReader(const std::filesystem::path &path)
+    : path_(path),
+      cached_current_offset_(0) {
+
+  fd_ = open(path.c_str(), O_RDONLY);
+  CHECK(fd_ >= 0) << "unable to open " << path << " for reading";
+
+  posix_fadvise(fd_, 0, 0, POSIX_FADV_SEQUENTIAL);
+}
+
+PosixSequentialFileReader::~PosixSequentialFileReader() {
+  close(fd_);
+}
+
+std::streamsize PosixSequentialFileReader::GetSize() const {
+  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
+  return fs::file_size(path_);
+}
+
+std::streamsize
+PosixSequentialFileReader::Read(void *buffer, std::streamoff offset, std::streamsize size) {
+  if (cached_current_offset_ != offset) {
+    lseek(fd_, offset, SEEK_SET);
+    cached_current_offset_ = offset;
+  }
+  int count = read(fd_, buffer, size);
+  cached_current_offset_ += count;
+
+  return Reader::Read(buffer, offset, count);
+}
+
+}  // namespace kysync

--- a/src/readers/reader.cc
+++ b/src/readers/reader.cc
@@ -1,5 +1,6 @@
 #include <glog/logging.h>
 #include <kysync/readers/file_reader.h>
+#include <kysync/readers/posix_sequential_file_reader.h>
 #include <kysync/readers/http_reader.h>
 #include <kysync/readers/memory_reader.h>
 #include <kysync/readers/reader.h>
@@ -62,7 +63,7 @@ std::unique_ptr<Reader> Reader::Create(const std::string &uri) {
       throw std::invalid_argument(uri);
     }
 
-    return std::make_unique<FileReader>(path);
+    return std::make_unique<PosixSequentialFileReader>(path);
   }
 
   std::string memory = "memory://";


### PR DESCRIPTION
…SEQUENTIAL) to make sequential file reads faster

Background:
I ran tests to test the raw read speed of phase 2 (analyzing the seed file). It looked like it was reading from the disk much slower that "cat" was able to read the file. I compared "cat" vs "dd" and on my machine, "cat" was able to read a 10gb file in 23 seconds, but "dd" was only able to read it in 36 seconds. kysync time was similar to "dd" time. I looked at the "cat" code and it was doing fdadvise(SEQUENTIAL) after it opened the file, and when I changed kysync to do that, our read time became similar to "cat" and improved from 36 second to 23 seconds.

Note that we do spend a lot of CPU time as well and the IO time happens in parallel to the CPU time. With a small number of threads we will still be CPU bound, but with a large number of threads and a high similarity we are IO bound (with a low similarity we are still CPU bound) and this change should see a modest performance improvement.