### PR TITLE
change WeakChecksum to a template function so it gets inlined

### DIFF
--- a/src/checksums/include/weak_checksum.h
+++ b/src/checksums/include/weak_checksum.h
@@ -17,17 +17,6 @@ namespace kysync {
 uint32_t WeakChecksum(const void *buffer, std::streamsize size);
 
 /**
- * call back function type used by rolling window checksum
- * this is called after each byte of data is processed
- * parameters passed are:
- * - the window offset from the original buffer (always negative!)
- * - the checksum of the data in the window
- * NOTE: the window size is assumed to be known to the user...
- */
-using WeakChecksumCallback =
-    std::function<void(std::streamoff offset, uint32_t wcs)>;
-
-/**
  * computes a running window checksum ala rsync
  *
  * - the window size is the same as the buffer size
@@ -43,18 +32,39 @@ using WeakChecksumCallback =
  *   even if it is the first block!
  *   so the first block should have a sentinel block filled with 0s before it.
  *
+ * callback param is a functor used by rolling window checksum
+ * this is called after each byte of data is processed
+ * parameters passed are:
+ * - the window offset from the original buffer (always negative!)
+ * - the checksum of the data in the window
+ *
+ * NOTE: the window size is assumed to be known to the user...
+ *
  * @param buffer
  * @param size
  * @param running_checksum
  * @param callback
  * @return
  */
+template <typename T>
 uint32_t WeakChecksum(
     const void *buffer,
     std::streamsize size,
     uint32_t running_checksum,
-    const WeakChecksumCallback &callback);
+    const T &callback) {
+  const auto *data = static_cast<const char *>(buffer);
+
+  auto a = static_cast<uint16_t>(running_checksum & 0xFFFF);
+  auto b = static_cast<uint16_t>(running_checksum >> 16);
+
+  for (std::streamsize i = 0; i < size; i++) {
+    a += data[i] - data[i - size];
+    b += a - size * data[i - size];
+    callback(i + 1 - size, b << 16 | a);
+  }
+
+  return b << 16 | a;
+}
 
 }  // namespace kysync
-
 #endif  // KSYNC_WEAK_CHECKSUM_H

--- a/src/checksums/weak_checksum.cc
+++ b/src/checksums/weak_checksum.cc
@@ -18,23 +18,4 @@ uint32_t WeakChecksum(const void *buffer, std::streamsize size) {
   return b << 16 | a;
 }
 
-uint32_t WeakChecksum(
-    const void *buffer,
-    std::streamsize size,
-    uint32_t running_checksum,
-    const WeakChecksumCallback &callback) {
-  const auto *data = static_cast<const char *>(buffer);
-
-  auto a = static_cast<uint16_t>(running_checksum & 0xFFFF);
-  auto b = static_cast<uint16_t>(running_checksum >> 16);
-
-  for (std::streamsize i = 0; i < size; i++) {
-    a += data[i] - data[i - size];
-    b += a - size * data[i - size];
-    callback(i + 1 - size, b << 16 | a);
-  }
-
-  return b << 16 | a;
-}
-
 }  // namespace kysync

--- a/src/commands/sync_command.cc
+++ b/src/commands/sync_command.cc
@@ -295,13 +295,6 @@ void SyncCommandImpl::AnalyzeSeedChunk(
     auto count = seed_reader->Read(buffer, seed_offset, block_size_);
     memset(buffer + count, 0, block_size_ - count);
 
-    /* I tried to "optimize" the following by manually inlining `weakChecksum`
-     * and then unrolling the inner loop. To my surprise this did not help...
-     * The MSVC compiler must be already doing it...
-     * We should verify that other compilers do reasonably well before we
-     * abandon the idea completely.
-     * https://github.com/kyotov/ksync/blob/2d98f83cd1516066416e8319fbfa995e3f49f3dd/commands/SyncCommand.cpp#L166-L220
-     */
     running_wcs = WeakChecksum(buffer, block_size_, running_wcs, callback);
 
     AdvanceProgress(block_size_);


### PR DESCRIPTION
In phase 2 (analyzing the seed file) when similarity=0, the WeakChecksum loop becomes a very tight loop that causes the callback to get called once per byte. With a 10gb file that is 10b times. The WeakChecksum function isn't being inlined and the callback is a virtual function call. Instead if we make it inline everything it gets about 50% faster on my machine. I see a comment that on windows it didn't make a difference, but on my linux box it does make a difference, With similarity=0 before I was getting 14mb/s, now with this change with it inlined (simply by making WeakChecksum a template function with a functor as the callback, instead of a function call and a virtual function callback, and verifying in the asm it is now inlined)  it went up to 21mb/s.