### PR TITLE
fix bug where last chunk was always ignored during analysis phase

### DIFF
--- a/src/commands/sync_command.cc
+++ b/src/commands/sync_command.cc
@@ -267,7 +267,7 @@ void SyncCommandImpl::AnalyzeSeedChunk(
       /* The `set` seems to improve performance. Previously the code was:
        * https://github.com/kyotov/ksync/blob/2d98f83cd1516066416e8319fbfa995e3f49f3dd/commands/SyncCommand.cpp#L128-L132
        */
-      if (--warmup < 0 && seed_offset + offset + block_size_ <= seed_size &&
+      if (--warmup < 0 && seed_offset + offset < seed_size &&
           (*set_)[wcs])
       {
         weak_checksum_matches_++;


### PR DESCRIPTION
This caused the last chunk to always be ignored. Note that it isn't a problem this chunk is less than block_size_ because we always have at least a block_size-sized memory buffer and we zero-fill any part past the end of the actual chunk up to block_size_ bytes.